### PR TITLE
Bug fix for newlines

### DIFF
--- a/ntds/dsdatabase.py
+++ b/ntds/dsdatabase.py
@@ -230,7 +230,8 @@ def dsBuildMaps(dsDatabase, workdir):
         except:
             sys.stderr.write("\n[!] Warning! Error at dsMapOffsetByLineId!\n")
             pass
-        line = dsDatabase.readline()
+        # read the line and strip both DOS and UNIX newlines from it to prevent non-empty strings for rightmost column
+        line = dsDatabase.readline().rstrip('\n').rstrip('\r')
         if line == "":
             break
         record = line.split('\t')


### PR DESCRIPTION
The newline characters are not stripped from lines of input. This causes the rightmost column to be non-empty. If the rightmost column happens to be the PEK index, the string is not empty (because it contains \n or \r\n) and it throws "[!] Warning! Multiple records with PEK entry!" and replaces the PEK key with newlines. This change simply strips the newlines